### PR TITLE
Add support for ipython 7.13.0

### DIFF
--- a/pylane/shell/ipython_embed.py
+++ b/pylane/shell/ipython_embed.py
@@ -129,7 +129,7 @@ class IPythonShell(InteractiveShellEmbed):
             exit(0)
         flag, op = raw[0], raw[1:]
         # TODO old interface which is not used, going to be deprecated.
-        flag is '0'
+        flag == '0'
         return op
 
     def remote_completer(self, ipcompleter, text, line=None, cursor_pos=None):

--- a/pylane/shell/ipython_embed.py
+++ b/pylane/shell/ipython_embed.py
@@ -78,7 +78,7 @@ class IPythonShell(InteractiveShellEmbed):
                 self, raw_cell, store_history, silent, shell_futures
             )
 
-        result = ExecutionResult()
+        result = ExecutionResult(None)
         self.displayhook.exec_result = result
 
         if (not raw_cell) or raw_cell.isspace():

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,8 @@ setup(
         # 'build_py': build_py
     # },
     install_requires=[
-        "ipython==5.7",
-        # 'ipython==5.8;python_version<"3.4"',
-        # 'ipython==7.2;python_version>="3.4"',
+        'ipython==5.8;python_version<"3.4"',
+        'ipython>=7.2;python_version>="3.4"',
         "Click==7.0",
     ],
     keywords=['debug', 'attach', 'gdb', 'shell']


### PR DESCRIPTION
Ubuntu 20.04LTS uses ipython3==7.13.0-1
https://packages.ubuntu.com/focal/ipython3

Using 5.7.0 prevents any imports when using the ipython shell.

Not 100% about giving None as `info` to ExectionResult [1], but the
ExecutionInfo [2] object it's supposed to hold only seems to be used
for its __repr__ attribute for debugging.

[1] https://github.com/ipython/ipython/blob/a8accc9ab5aa97c2fd21149d421f0c6917e060b2/IPython/core/interactiveshell.py#L319
[2] https://github.com/ipython/ipython/blob/a8accc9ab5aa97c2fd21149d421f0c6917e060b2/IPython/core/interactiveshell.py#L284